### PR TITLE
Scaffold Python project for MediaWiki agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # mediawiki-agent
 
 [Smolagents](https://smolagents.org) components to interact with [pywikibot](https://pypi.org/project/pywikibot/).
+
+## Installation
+
+To install the necessary dependencies, run the following command:
+
+```bash
+pip install smolagents pywikibot
+```

--- a/mediawiki_agent/tools.py
+++ b/mediawiki_agent/tools.py
@@ -1,0 +1,16 @@
+import pywikibot
+from smolagents.tools import Tool
+
+class GetPageContentTool(Tool):
+    name = "get_page_content"
+    description = "Gets the content of a MediaWiki page."
+
+    def __init__(self, site_url):
+        super().__init__()
+        self.site = pywikibot.Site(url=site_url)
+
+    def run(self, page_title: str) -> str:
+        page = pywikibot.Page(self.site, page_title)
+        return page.text
+
+# Additional tools can be added similarly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mediawiki-agent"
+version = "0.1.0"
+description = "smolagent Tools for interacting with MediaWiki instances"
+authors = [{name = "kmarekspartz"}]
+dependencies = [
+    "smolagents",
+    "pywikibot"
+]
+
+[tool.hatch.build.targets.sdist]
+exclude = ["/tests"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,3 @@
+def test_get_page_content_tool():
+    # Example test; in practice, use a test or mock wiki instance
+    assert True


### PR DESCRIPTION
Jules says:

This commit introduces the basic project structure for developing ways for me to interact with MediaWiki instances.

Key changes include:
- Creation of `pyproject.toml` with `smolagents` and `pywikibot` dependencies.
- Addition of an example tool `GetPageContentTool` in `mediawiki_agent/tools.py`.
- Setup of a basic test file in `tests/test_tools.py`.
- Creation of `mediawiki_agent/__init__.py`.
- Update of `README.md` with installation instructions.
- The `.gitignore` file was already comprehensive and covered the necessary Python ignores.