### PR TITLE
feat: Update to Python 3.13 and integrate mypy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.13"]
 
     steps:
     - uses: actions/checkout@v3
@@ -33,6 +33,9 @@ jobs:
     - name: Lint with Ruff
       run: |
         ruff check .
+    - name: Type check with mypy
+      run: |
+        mypy .
     - name: Run tests
       run: |
         pytest tests/

--- a/mediawiki_agent/agent.py
+++ b/mediawiki_agent/agent.py
@@ -3,7 +3,7 @@ class MediaWikiAgent:
         self.api_url = api_url
 
     # Placeholder for login functionality
-    def login(self, username, password):
+    def login(self, username: str, password: str) -> bool:
         # In a real implementation, this would interact with the MediaWiki API
         # For now, it can be a mock or do nothing
         print(f"Attempting to log in user {username} to {self.api_url}")
@@ -11,7 +11,7 @@ class MediaWikiAgent:
         return True
 
     # Placeholder for edit functionality
-    def edit_page(self, page_title: str, content: str, summary: str = ""):
+    def edit_page(self, page_title: str, content: str, summary: str = "") -> bool:
         # In a real implementation, this would interact with the MediaWiki API
         print(
             f"Attempting to edit page {page_title} on {self.api_url} with summary: {summary}"

--- a/mediawiki_agent/tools.py
+++ b/mediawiki_agent/tools.py
@@ -13,7 +13,8 @@ class GetPageContentTool(Tool):
         super().__init__()
         self.site: pywikibot.Site = pywikibot.Site(url=site_url)
 
-    def forward(self, page_title: str) -> str: # Renamed from run
+    # Renamed from run
+    def forward(self, page_title: str) -> str:
         page = pywikibot.Page(self.site, page_title)
         return page.text
 

--- a/mediawiki_agent/tools.py
+++ b/mediawiki_agent/tools.py
@@ -9,9 +9,9 @@ class GetPageContentTool(Tool):
     outputs = {"page_content": {"type": "string", "description": "The text content of the MediaWiki page."}}
     output_type = "string"
 
-    def __init__(self, site_url):
+    def __init__(self, site_url: str) -> None:
         super().__init__()
-        self.site = pywikibot.Site(url=site_url)
+        self.site: pywikibot.Site = pywikibot.Site(url=site_url)
 
     def forward(self, page_title: str) -> str: # Renamed from run
         page = pywikibot.Page(self.site, page_title)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+python_version = 3.13
+warn_return_any = True
+warn_unused_configs = True
+ignore_missing_imports = True
+# Add more specific rules or strictness options as needed later.
+# For now, focus on getting a basic configuration in place.
+
+# Specify files/directories to check.
+# Adjust if only specific directories should be checked initially.
+files = mediawiki_agent, tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "mediawiki-agent"
 version = "0.1.0"
 description = "smolagent Tools for interacting with MediaWiki instances"
 authors = [{name = "kmarekspartz"}]
-requires-python = ">=3.10"
+requires-python = ">=3.13"
 dependencies = [
     "smolagents",
     "pywikibot"
@@ -22,5 +22,6 @@ test = [
     "pytest-mock"
 ]
 lint = [
-    "ruff"
+    "ruff",
+    "mypy"
 ]


### PR DESCRIPTION
This commit updates the project to require Python 3.13 and integrates mypy for static type checking.

Changes include:
- Updated `pyproject.toml` to set `requires-python = ">=3.13"`.
- Modified the GitHub Actions workflow (`.github/workflows/test.yml`) to use Python 3.13.
- Added `mypy` to the `lint` optional-dependencies in `pyproject.toml`.
- Created a `mypy.ini` configuration file with basic settings.
- Added a "Type check with mypy" step to the GitHub Actions workflow.
- Introduced initial type hints to `mediawiki_agent/agent.py` and `mediawiki_agent/tools.py`.

Mypy will now run as part of the CI pipeline to help ensure type safety.