### PR TITLE
Here's the commit message you requested:

### DIFF
--- a/tests/test_mediawiki_agent.py
+++ b/tests/test_mediawiki_agent.py
@@ -1,3 +1,4 @@
+import pytest
 from mediawiki_agent.agent import MediaWikiAgent
 
 
@@ -6,16 +7,40 @@ def test_mediawiki_agent_initialization():
     assert agent.api_url == "https://test.wikipedia.org/w/api.php"
 
 
+@pytest.mark.skip(reason="Feature not yet implemented")
 def test_mediawiki_agent_login():
     # Mock the login functionality
     # Add actual login tests based on your implementation
     pass
 
 
+@pytest.mark.skip(reason="Feature not yet implemented")
 def test_mediawiki_agent_edit():
     # Add tests for page editing functionality
     # Mock the API calls and verify the behavior
     pass
 
 
-# Add more test cases based on your implemented functionality
+@pytest.mark.skip(reason="Feature not yet implemented")
+def test_search_pages_placeholder():
+    pass
+
+
+@pytest.mark.skip(reason="Feature not yet implemented")
+def test_category_operations_placeholder():
+    pass
+
+
+@pytest.mark.skip(reason="Feature not yet implemented")
+def test_access_page_history_placeholder():
+    pass
+
+
+@pytest.mark.skip(reason="Feature not yet implemented")
+def test_site_information_placeholder():
+    pass
+
+
+@pytest.mark.skip(reason="Feature not yet implemented")
+def test_file_uploads_placeholder():
+    pass


### PR DESCRIPTION
Add placeholder tests for unimplemented features

This commit introduces placeholder tests for several features mentioned in the README.md but not yet implemented in the MediaWikiAgent.

The following tests have been updated or added in `tests/test_mediawiki_agent.py`:

- `test_mediawiki_agent_login`: Marked as skipped.
- `test_mediawiki_agent_edit`: Marked as skipped.
- `test_search_pages_placeholder`: New skipped test.
- `test_category_operations_placeholder`: New skipped test.
- `test_access_page_history_placeholder`: New skipped test.
- `test_site_information_placeholder`: New skipped test.
- `test_file_uploads_placeholder`: New skipped test.

These tests use `@pytest.mark.skip(reason="Feature not yet implemented")` to ensure they are not executed until the corresponding features are developed. This helps in tracking future test development and provides a structure for when features are implemented.