### PR TITLE
Okay, I've added two new capabilities for interacting with MediaWiki …

### DIFF
--- a/mediawiki_agent/tools.py
+++ b/mediawiki_agent/tools.py
@@ -1,6 +1,7 @@
 import pywikibot
+import requests
 from smolagents import tool
-from typing import Any
+from typing import Any, List
 
 
 @tool
@@ -18,3 +19,56 @@ def get_page_content(page_title: str) -> Any:  # str
     site = pywikibot.Site()
     page = pywikibot.Page(site, page_title)
     return page.text
+
+
+@tool
+def add_text(
+    page_title: str, text_to_add: str, summary: str, position: str = "bottom"
+) -> None:
+    """
+    Adds text to a MediaWiki page, either at the top or bottom.
+
+    Args:
+        page_title: The title of the MediaWiki page.
+        text_to_add: The text to add to the page.
+        summary: The summary of the edit.
+        position: Where to add the text, either 'top' or 'bottom'. Defaults to 'bottom'.
+    """
+    site = pywikibot.Site()
+    page = pywikibot.Page(site, page_title)
+
+    if position == "top":
+        page.text = text_to_add + page.text
+    elif position == "bottom":
+        page.text = page.text + text_to_add
+    else:
+        raise ValueError("Position must be either 'top' or 'bottom'")
+
+    page.save(summary)
+
+
+@tool
+def check_weblinks(page_title: str) -> List[str]:
+    """
+    Checks all external links on a MediaWiki page for 4xx or 5xx HTTP status codes.
+
+    Args:
+        page_title: The title of the MediaWiki page.
+
+    Returns:
+        A list of URLs that are broken.
+    """
+    site = pywikibot.Site()
+    page = pywikibot.Page(site, page_title)
+    broken_links: List[str] = []
+
+    for link in page.extlinks():
+        try:
+            response = requests.get(link, timeout=10)  # Added timeout
+            if response.status_code >= 400:
+                broken_links.append(link)
+        except requests.exceptions.RequestException:
+            # Includes ConnectionError, Timeout, TooManyRedirects, etc.
+            broken_links.append(link)
+
+    return broken_links

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,11 +1,16 @@
-from mediawiki_agent.tools import get_page_content
+import unittest
+from unittest.mock import patch, MagicMock
+
+import requests  # For requests.exceptions.RequestException
+
+from mediawiki_agent.tools import get_page_content, add_text, check_weblinks
 
 
-def test_get_page_content_tool(mocker):
+# Existing test - keep it as is
+def test_get_page_content_tool(mocker):  # mocker is from pytest-mock
     mock_site_instance = mocker.MagicMock()
     mocker.patch("pywikibot.Site", return_value=mock_site_instance)
 
-    # 2. Mock pywikibot.Page
     mock_page_instance = mocker.MagicMock()
     mock_page_instance.text = "This is the page content."
     mock_page_constructor = mocker.patch(
@@ -13,10 +18,203 @@ def test_get_page_content_tool(mocker):
     )
 
     page_title = "Test Page"
-
-    # 3. Instantiate the tool
     result = get_page_content(page_title=page_title)
 
-    # 5. Assertions
     mock_page_constructor.assert_called_once_with(mock_site_instance, page_title)
     assert result == "This is the page content."
+
+
+class TestAddText(unittest.TestCase):
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_add_text_bottom(self, MockSite, MockPage):
+        mock_site_instance = MockSite.return_value
+        mock_page_instance = MockPage.return_value
+        mock_page_instance.text = "Existing content"
+
+        page_title = "Test Page"
+        text_to_add = " New text"
+        summary = "Test summary bottom"
+
+        add_text(page_title, text_to_add, summary, position="bottom")
+
+        MockSite.assert_called_once()
+        MockPage.assert_called_once_with(mock_site_instance, page_title)
+        self.assertEqual(mock_page_instance.text, "Existing content New text")
+        mock_page_instance.save.assert_called_once_with(summary)
+
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_add_text_top(self, MockSite, MockPage):
+        mock_site_instance = MockSite.return_value
+        mock_page_instance = MockPage.return_value
+        mock_page_instance.text = "Existing content"
+
+        page_title = "Test Page"
+        text_to_add = "New text "
+        summary = "Test summary top"
+
+        add_text(page_title, text_to_add, summary, position="top")
+
+        MockSite.assert_called_once()
+        MockPage.assert_called_once_with(mock_site_instance, page_title)
+        self.assertEqual(mock_page_instance.text, "New text Existing content")
+        mock_page_instance.save.assert_called_once_with(summary)
+
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_add_text_empty_page_bottom(self, MockSite, MockPage):
+        MockSite()  # Ensures Site() is called
+        mock_page_instance = MockPage.return_value
+        mock_page_instance.text = ""
+
+        page_title = "Empty Page"
+        text_to_add = "Some text"
+        summary = "Test summary empty bottom"
+
+        add_text(page_title, text_to_add, summary, position="bottom")
+
+        self.assertEqual(mock_page_instance.text, "Some text")
+        mock_page_instance.save.assert_called_once_with(summary)
+
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_add_text_empty_page_top(self, MockSite, MockPage):
+        MockSite()  # Ensures Site() is called
+        mock_page_instance = MockPage.return_value
+        mock_page_instance.text = ""
+
+        page_title = "Empty Page"
+        text_to_add = "Some text"
+        summary = "Test summary empty top"
+
+        add_text(page_title, text_to_add, summary, position="top")
+
+        self.assertEqual(mock_page_instance.text, "Some text")
+        mock_page_instance.save.assert_called_once_with(summary)
+
+
+class TestCheckWeblinks(unittest.TestCase):
+    @patch("mediawiki_agent.tools.requests.get")
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_check_weblinks_no_broken_links(self, MockSite, MockPage, MockRequestsGet):
+        mock_site_instance = (
+            MockSite.return_value
+        )  # Used in MockPage.assert_called_once_with
+        mock_page_instance = MockPage.return_value
+
+        urls = ["http://example.com/working"]
+        mock_page_instance.extlinks.return_value = urls
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        MockRequestsGet.return_value = mock_response
+
+        page_title = "Test Page"
+        result = check_weblinks(page_title)
+
+        MockSite.assert_called_once()
+        MockPage.assert_called_once_with(mock_site_instance, page_title)
+        MockRequestsGet.assert_called_once_with(urls[0], timeout=10)
+        self.assertEqual(result, [])
+
+    @patch("mediawiki_agent.tools.requests.get")
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_check_weblinks_one_broken_link_status_code(
+        self, MockSite, MockPage, MockRequestsGet
+    ):
+        MockSite()  # Ensures Site() is called
+        mock_page_instance = MockPage.return_value
+
+        urls = ["http://example.com/broken"]
+        mock_page_instance.extlinks.return_value = urls
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        MockRequestsGet.return_value = mock_response
+
+        page_title = "Test Page"
+        result = check_weblinks(page_title)
+
+        self.assertEqual(result, ["http://example.com/broken"])
+        MockRequestsGet.assert_called_once_with(urls[0], timeout=10)
+
+    @patch("mediawiki_agent.tools.requests.get")
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_check_weblinks_one_broken_link_exception(
+        self, MockSite, MockPage, MockRequestsGet
+    ):
+        MockSite()  # Ensures Site() is called
+        mock_page_instance = MockPage.return_value
+
+        urls = ["http://example.com/timeout"]
+        mock_page_instance.extlinks.return_value = urls
+
+        MockRequestsGet.side_effect = requests.exceptions.RequestException
+
+        page_title = "Test Page"
+        result = check_weblinks(page_title)
+
+        self.assertEqual(result, ["http://example.com/timeout"])
+        MockRequestsGet.assert_called_once_with(urls[0], timeout=10)
+
+    @patch("mediawiki_agent.tools.requests.get")
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_check_weblinks_mixed_links(self, MockSite, MockPage, MockRequestsGet):
+        MockSite()  # Ensures Site() is called
+        mock_page_instance = MockPage.return_value
+
+        urls = [
+            "http://example.com/working",
+            "http://example.com/broken404",
+            "http://example.com/broken_timeout",
+        ]
+        mock_page_instance.extlinks.return_value = urls
+
+        def side_effect_func(url, timeout):
+            if url == "http://example.com/working":
+                response = MagicMock()
+                response.status_code = 200
+                return response
+            elif url == "http://example.com/broken404":
+                response = MagicMock()
+                response.status_code = 404
+                return response
+            elif url == "http://example.com/broken_timeout":
+                raise requests.exceptions.RequestException
+            return MagicMock()  # Should not happen
+
+        MockRequestsGet.side_effect = side_effect_func
+
+        page_title = "Test Page"
+        result = check_weblinks(page_title)
+
+        self.assertEqual(
+            result,
+            ["http://example.com/broken404", "http://example.com/broken_timeout"],
+        )
+        self.assertEqual(MockRequestsGet.call_count, 3)
+
+    @patch("mediawiki_agent.tools.requests.get")
+    @patch("mediawiki_agent.tools.pywikibot.Page")
+    @patch("mediawiki_agent.tools.pywikibot.Site")
+    def test_check_weblinks_no_external_links(
+        self, MockSite, MockPage, MockRequestsGet
+    ):
+        MockSite()  # Ensures Site() is called
+        mock_page_instance = MockPage.return_value
+        mock_page_instance.extlinks.return_value = []
+
+        page_title = "Test Page"
+        result = check_weblinks(page_title)
+
+        self.assertEqual(result, [])
+        MockRequestsGet.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…sites using pywikibot:

1.  I can now add specified text to the top or bottom of a given MediaWiki page. You'll need to provide the page title, the text to add, an edit summary, and optionally specify whether to add it at the 'top' or 'bottom' (I'll assume 'bottom' if you don't specify).

2.  I can also check a given MediaWiki page for broken external links. Just give me the page title, and I'll return a list of URLs that appear to be broken (either due to HTTP errors or connection problems).

I've also run through various scenarios to make sure these new abilities work correctly, such as adding text in different places, handling empty pages, and checking pages with various combinations of working and broken links.

Everything looks good and is working as expected.